### PR TITLE
Fixed "BUG: Can't immediately search for graduate courses"

### DIFF
--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -22,8 +22,11 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
 
   // Stryker disable all : not sure how to test/mock local storage
   const localSubject = localStorage.getItem("BasicSearch.Subject");
+  console.log(`BasicCourseSearchForm ln25: localSubject = ${localSubject}`);
   const localQuarter = localStorage.getItem("BasicSearch.Quarter");
-  const localLevel = localStorage.getItem("BasicSearch.CourseLevel");
+  console.log(`BasicCourseSearchForm ln27: localQuarter = ${localQuarter}`);
+  const localLevel = localStorage.getItem("BasicSearch.Level");
+  console.log(`BasicCourseSearchForm ln29: localLevel = ${localLevel}`);
 
   const {
     data: subjects,
@@ -38,14 +41,18 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
 
   const defaultSubjectArea = "ANTH";
   const [quarter, setQuarter] = useState(localQuarter || quarters[0].yyyyq);
+  console.log(`BasicCourseSearchForm ln44: quarter, setQuarter = ${quarter} ${setQuarter}`);
   const [subject, setSubject] = useState(
     localSubject || subjects[0]?.subjectCode || defaultSubjectArea,
   );
-  const [level, setLevel] = useState(localLevel || "U");
+    console.log(`BasicCourseSearchForm ln48: subject, setSubject = ${subject} ${setSubject}`);
+  const [level, setLevel] = useState(localLevel);
+    console.log(`BasicCourseSearchForm ln50: level, setLevel = ${level} ${setLevel}`);
 
   const handleSubmit = (event) => {
     event.preventDefault();
     fetchJSON(event, { quarter, subject, level });
+    console.log(`BasicCourseSearchForm ln55: quarter, subject, level = ${quarter} ${subject} ${level}`);
   };
 
   // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better

--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -22,11 +22,8 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
 
   // Stryker disable all : not sure how to test/mock local storage
   const localSubject = localStorage.getItem("BasicSearch.Subject");
-  console.log(`BasicCourseSearchForm ln25: localSubject = ${localSubject}`);
   const localQuarter = localStorage.getItem("BasicSearch.Quarter");
-  console.log(`BasicCourseSearchForm ln27: localQuarter = ${localQuarter}`);
   const localLevel = localStorage.getItem("BasicSearch.Level");
-  console.log(`BasicCourseSearchForm ln29: localLevel = ${localLevel}`);
 
   const {
     data: subjects,
@@ -41,18 +38,13 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
 
   const defaultSubjectArea = "ANTH";
   const [quarter, setQuarter] = useState(localQuarter || quarters[0].yyyyq);
-  console.log(`BasicCourseSearchForm ln44: quarter, setQuarter = ${quarter} ${setQuarter}`);
   const [subject, setSubject] = useState(
     localSubject || subjects[0]?.subjectCode || defaultSubjectArea,
   );
-    console.log(`BasicCourseSearchForm ln48: subject, setSubject = ${subject} ${setSubject}`);
-  const [level, setLevel] = useState(localLevel);
-    console.log(`BasicCourseSearchForm ln50: level, setLevel = ${level} ${setLevel}`);
-
+  const [level, setLevel] = useState(localLevel || "U");
   const handleSubmit = (event) => {
     event.preventDefault();
     fetchJSON(event, { quarter, subject, level });
-    console.log(`BasicCourseSearchForm ln55: quarter, subject, level = ${quarter} ${subject} ${level}`);
   };
 
   // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better

--- a/frontend/src/main/components/Levels/SingleLevelDropdown.js
+++ b/frontend/src/main/components/Levels/SingleLevelDropdown.js
@@ -9,21 +9,16 @@ const SingleLevelDropdown = ({
   label = "Course Level",
 }) => {
   const localSearchLevel = localStorage.getItem(controlId);
-  console.log(`SingleLevelDropdown ln12: localSearchLevelFetch, controlId = ${localSearchLevel}  ${controlId}`);
   const [levelState, setLevelState] = useState(
     // Stryker disable next-line all : not sure how to test/mock local storage
     localSearchLevel || "U",
   );
-  console.log(`SingleLevelDropdown ln17: levelState = ${levelState}`);
 
   const handleLevelOnChange = (event) => {
     const selectedLevel = event.target.value;
-    console.log(`SingleLevelDropdown ln21: selectedLevel = ${selectedLevel}`);
     localStorage.setItem(controlId, selectedLevel);
     setLevelState(selectedLevel);
-    console.log(`SingleLevelDropdown ln24: controlId, setLevelState, selectedLevel  = ${controlId}  ${setLevelState}  ${selectedLevel}`);
     setLevel(selectedLevel);
-    console.log(`SingleLevelDropdown ln26: setLevel = ${setLevel}`);
     if (onChange != null) {
       onChange(event);
     }

--- a/frontend/src/main/components/Levels/SingleLevelDropdown.js
+++ b/frontend/src/main/components/Levels/SingleLevelDropdown.js
@@ -9,15 +9,21 @@ const SingleLevelDropdown = ({
   label = "Course Level",
 }) => {
   const localSearchLevel = localStorage.getItem(controlId);
+  console.log(`SingleLevelDropdown ln12: localSearchLevelFetch, controlId = ${localSearchLevel}  ${controlId}`);
   const [levelState, setLevelState] = useState(
     // Stryker disable next-line all : not sure how to test/mock local storage
     localSearchLevel || "U",
   );
+  console.log(`SingleLevelDropdown ln17: levelState = ${levelState}`);
 
-  const handleLeveltoChange = (event) => {
-    localStorage.setItem(controlId, event.target.value);
-    setLevelState(event.target.value);
-    setLevel(event.target.value);
+  const handleLevelOnChange = (event) => {
+    const selectedLevel = event.target.value;
+    console.log(`SingleLevelDropdown ln21: selectedLevel = ${selectedLevel}`);
+    localStorage.setItem(controlId, selectedLevel);
+    setLevelState(selectedLevel);
+    console.log(`SingleLevelDropdown ln24: controlId, setLevelState, selectedLevel  = ${controlId}  ${setLevelState}  ${selectedLevel}`);
+    setLevel(selectedLevel);
+    console.log(`SingleLevelDropdown ln26: setLevel = ${setLevel}`);
     if (onChange != null) {
       onChange(event);
     }
@@ -29,7 +35,7 @@ const SingleLevelDropdown = ({
       <Form.Control
         as="select"
         value={levelState}
-        onChange={handleLeveltoChange}
+        onChange={handleLevelOnChange}
       >
         {levels.map(function (object, i) {
           const key = `${controlId}-option-${i}`;

--- a/frontend/src/tests/components/Levels/SingleLevelDropdown.test.js
+++ b/frontend/src/tests/components/Levels/SingleLevelDropdown.test.js
@@ -102,7 +102,7 @@ describe("SingleLevelDropdown tests", () => {
 
   test("when localstorage has a value, it is passed to useState", async () => {
     const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
-    getItemSpy.mockImplementation(() => "U"); //[TODO: change this to be not the default value]
+    getItemSpy.mockImplementation(() => "G");
 
     const setLevelStateSpy = jest.fn();
     useState.mockImplementation((x) => [x, setLevelStateSpy]);
@@ -116,7 +116,7 @@ describe("SingleLevelDropdown tests", () => {
       />,
     );
 
-    await waitFor(() => expect(useState).toBeCalledWith("U"));
+    await waitFor(() => expect(useState).toBeCalledWith("G"));
   });
 
   test("when localstorage has no value, U is passed to useState", async () => {

--- a/frontend/src/tests/components/Levels/SingleLevelDropdown.test.js
+++ b/frontend/src/tests/components/Levels/SingleLevelDropdown.test.js
@@ -102,7 +102,7 @@ describe("SingleLevelDropdown tests", () => {
 
   test("when localstorage has a value, it is passed to useState", async () => {
     const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
-    getItemSpy.mockImplementation(() => "U");
+    getItemSpy.mockImplementation(() => "U"); //[TODO: change this to be not the default value]
 
     const setLevelStateSpy = jest.fn();
     useState.mockImplementation((x) => [x, setLevelStateSpy]);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,6 +25,7 @@ spring.mvc.pathmatch.matching-strategy = ANT_PATH_MATCHER
 server.compression.enabled=false
 
 spring.data.mongodb.uri=${MONGODB_URI:${env.MONGODB_URI:mongodb+srv://fakeUsername:fakePassword@cluster0.ulqcw.mongodb.net/fakeDatabase?retryWrites=true&w=majority}}
+spring.data.mongodb.database=database
 
 spring.mvc.format.date-time=iso
 


### PR DESCRIPTION
Closes #3 
https://proj-courses-bwr02-dev.dokku-07.cs.ucsb.edu
![Screenshot 2024-02-28 at 8 15 20 PM](https://github.com/ucsb-cs156-w24/proj-courses-w24-5pm-3/assets/97922340/dc3614a8-b73a-4168-9d67-411418f20d8a)

Error was that BasicCourseSearch was not searching for the correct localStorage location and was failing to find localStorage for levels. Also, improved tests to better detect issues with the stored value being saved to a different value than default.
This PR better aligns the code for the Levels dropdown with the other dropdowns to make it easier to debug.
It also adds the needed changes to the application.properties to allow dokku to use mongo
