### PR TITLE
Add missing stories for CourseForm and PersonalSchedulesDetailsPage

### DIFF
--- a/frontend/src/stories/components/Courses/CourseForm.stories.js
+++ b/frontend/src/stories/components/Courses/CourseForm.stories.js
@@ -1,0 +1,39 @@
+import React from "react";
+
+import CourseForm from "main/components/Courses/CourseForm";
+import { allTheSubjects } from "fixtures/subjectFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+export default {
+  title: "components/Courses/CourseForm",
+  component: CourseForm,
+  parameters: {
+    mockData: [
+      {
+        url: "/api/UCSBSubjects/all",
+        method: "GET",
+        status: 200,
+        response: allTheSubjects,
+      },
+      {
+        url: "/api/systemInfo",
+        method: "GET",
+        status: 200,
+        response: systemInfoFixtures.showingBothStartAndEndQtr,
+      },
+    ],
+  },
+};
+
+const Template = (args) => {
+  return <CourseForm {...args} />;
+};
+
+export const Default = Template.bind({});
+
+Default.args = {
+  submitText: "Create",
+  fetchJSON: (_event, data) => {
+    console.log("Submit was clicked, data=", data);
+  },
+};

--- a/frontend/src/stories/pages/HomePage/PersonalSchedules/PersonalSchedulesDetailsPage.stories.js
+++ b/frontend/src/stories/pages/HomePage/PersonalSchedules/PersonalSchedulesDetailsPage.stories.js
@@ -1,0 +1,12 @@
+import React from "react";
+
+import PersonalSchedulesDetailsPage from "main/pages/PersonalSchedules/PersonalSchedulesDetailsPage";
+
+export default {
+  title: "pages/PersonalSchedules/PersonalSchedulesDetailsPage",
+  component: PersonalSchedulesDetailsPage,
+};
+
+const Template = () => <PersonalSchedulesDetailsPage />;
+
+export const Default = Template.bind({});


### PR DESCRIPTION
In this PR, I discovered missing stories and added CourseForm.stories.js, and PersonalSchedulesDetailsPage.stories.js. Now, these files can be viewed on storybook and easily modifiable by future programmers.
https://ucsb-cs156-w24.github.io/proj-courses-w24-5pm-3/prs/31/storybook/

<img width="1420" alt="Screenshot 2024-03-05 at 6 04 55 PM" src="https://github.com/ucsb-cs156-w24/proj-courses-w24-5pm-3/assets/97635056/93e6a08b-7a45-4f7d-9129-d3145394e0c9">
<img width="1438" alt="Screenshot 2024-03-05 at 6 05 33 PM" src="https://github.com/ucsb-cs156-w24/proj-courses-w24-5pm-3/assets/97635056/05deae03-0a96-45f8-9bf9-bb0fc766fedb">

Closes #30 