### PR TITLE
Refactor: Moved page links from Navbar into pages

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -64,22 +64,10 @@ export default function AppNavbar({
                   data-testid="appnavbar-personalschedules-dropdown"
                 >
                   <NavDropdown.Item
-                    href="/personalschedules/create"
-                    data-testid="appnavbar-personalschedules-create"
-                  >
-                    Add Schedule
-                  </NavDropdown.Item>
-                  <NavDropdown.Item
                     href="/personalschedules/list"
                     data-testid="appnavbar-personalschedules-list"
                   >
                     All Schedules
-                  </NavDropdown.Item>
-                  <NavDropdown.Item
-                    href="/courses/create"
-                    data-testid="appnavbar-courses-create"
-                  >
-                    Add Course
                   </NavDropdown.Item>
                   <NavDropdown.Item
                     href="/courses/list"

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesIndexPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesIndexPage.js
@@ -5,6 +5,9 @@ import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import PersonalSchedulesTable from "main/components/PersonalSchedules/PersonalSchedulesTable";
 import { useCurrentUser } from "main/utils/currentUser";
 
+import { Button } from "react-bootstrap";
+import { useNavigate } from "react-router-dom";
+
 export default function PersonalSchedulesIndexPage() {
   const currentUser = useCurrentUser();
 
@@ -19,6 +22,14 @@ export default function PersonalSchedulesIndexPage() {
     [],
   );
 
+  const navigate = useNavigate();
+  const addScheduleCallback = () => {
+    navigate(`/personalschedules/create`);
+  };
+  const addCourseCallback = () => {
+    navigate(`/courses/create`);
+  };
+
   return (
     <BasicLayout>
       <div className="pt-2">
@@ -27,6 +38,20 @@ export default function PersonalSchedulesIndexPage() {
           personalSchedules={personalSchedules}
           currentUser={currentUser}
         />
+
+        <Button
+          onClick={addScheduleCallback}
+          data-testid="personalschedulespage-addschedule-button"
+        >
+          Add New Schedule
+        </Button>
+        <span> </span>
+        <Button
+          onClick={addCourseCallback}
+          data-testid="personalschedulespage-addcourse-button"
+        >
+          Add New Course
+        </Button>
       </div>
     </BasicLayout>
   );

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -205,14 +205,10 @@ describe("AppNavbar tests", () => {
     expect(
       await screen.findByTestId("appnavbar-personalschedules-list"),
     ).toBeInTheDocument();
-    expect(
-      screen.getByTestId(/appnavbar-personalschedules-create/),
-    ).toBeInTheDocument();
 
     expect(
       await screen.findByTestId("appnavbar-courses-list"),
     ).toBeInTheDocument();
-    expect(screen.getByTestId(/appnavbar-courses-create/)).toBeInTheDocument();
   });
 
   test("renders the Course Description menu correctly", async () => {

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesIndexPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesIndexPage.test.js
@@ -20,6 +20,12 @@ jest.mock("react-toastify", () => {
   };
 });
 
+const mockedNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
 describe("PersonalSchedulesIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
@@ -199,5 +205,40 @@ describe("PersonalSchedulesIndexPage tests", () => {
         "PersonalSchedule with id 1 was deleted",
       );
     });
+  });
+
+  test("both buttons navigate to the correct pages", async () => {
+    setupUserOnly();
+    const queryClient = new QueryClient();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PersonalSchedulesIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId(`personalschedulespage-addschedule-button`),
+    ).toBeInTheDocument();
+    const addScheduleButton = screen.getByTestId(
+      `personalschedulespage-addschedule-button`,
+    );
+    fireEvent.click(addScheduleButton);
+    await waitFor(() =>
+      expect(mockedNavigate).toBeCalledWith("/personalschedules/create"),
+    );
+
+    expect(
+      await screen.findByTestId(`personalschedulespage-addcourse-button`),
+    ).toBeInTheDocument();
+    const addCourseButton = screen.getByTestId(
+      `personalschedulespage-addcourse-button`,
+    );
+    fireEvent.click(addCourseButton);
+    await waitFor(() =>
+      expect(mockedNavigate).toBeCalledWith("/courses/create"),
+    );
   });
 });


### PR DESCRIPTION
In this PR, we made the navbar more intuitive by 1) removing the "Add schedules" and "Add courses" links from the navbar, and 2) making those page links into buttons on the bottom of the "Personal schedules" page

Closes #25 

Dokku dev link: https://proj-courses-sophiattran-dev.dokku-07.cs.ucsb.edu/

Before: 
![image](https://github.com/ucsb-cs156-w24/proj-courses-w24-5pm-3/assets/92010986/8ce165cb-9497-4f00-8887-600f744e6ac3)

After: 
![image](https://github.com/ucsb-cs156-w24/proj-courses-w24-5pm-3/assets/92010986/31526994-8619-40d0-a828-3ac2e78f56ab)

Notes:
I chose to keep the "All schedules" and "All Courses" pages in the Navbar drop down because those two pages are related and it would make the Navbar more congested if both were moved to individual page links instead of a drop down. 
I added the "Add Course" button into the "All Personal Schedules" page rather than the "Personal Schedule Details" page because doing so would require more refactoring to ensure that the course automatically adds to the schedule the user was looking at. I'm leaving that for future students to implement.