### PR TITLE
FEATURE: Add sections to personal schedule directly from search

### DIFF
--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -28,6 +28,7 @@ export default function SectionsTable({ sections }) {
   // Stryker disable BooleanLiteral
   const [showModal, setShowModal] = useState(false);
   const [fetchSchedules, setFetchSchedules] = useState(false);
+  // Stryker disable next-line all : initalState of selectedEnrollCode does not matter and doesnt need to be tested
   const [selectedEnrollCode, setSelectedEnrollCode] = useState("");
 
   const handleShow = () => {
@@ -242,11 +243,7 @@ export default function SectionsTable({ sections }) {
           <Form>
             <Form.Group className="mb-3" data-testid="ModalForm-enrollCd">
               <Form.Label>Enroll Code</Form.Label>
-              <Form.Control
-                type="text"
-                value={selectedEnrollCode || ""}
-                readOnly
-              />
+              <Form.Control type="text" value={selectedEnrollCode} readOnly />
             </Form.Group>
             <Form.Group className="mb-3" data-testid="ModalForm-psId">
               <PersonalScheduleDropdown

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -2,8 +2,8 @@ import SectionsTableBase from "main/components/SectionsTableBase";
 import PersonalScheduleDropdown from "../PersonalSchedules/PersonalScheduleDropdown";
 
 // import { useNavigate } from "react-router-dom";
-import React, { useState, useEffect } from 'react';
-import { Modal, Button, Form } from 'react-bootstrap';
+import React, { useState, useEffect } from "react";
+import { Modal, Button, Form } from "react-bootstrap";
 import { toast } from "react-toastify";
 import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
@@ -24,20 +24,20 @@ function getFirstVal(values) {
 }
 
 export default function SectionsTable({ sections }) {
-
+  // Stryker restore all
+  // Stryker disable BooleanLiteral
   const [showModal, setShowModal] = useState(false);
   const [fetchSchedules, setFetchSchedules] = useState(false);
   const [selectedEnrollCode, setSelectedEnrollCode] = useState("");
-  // const navigate = useNavigate();
 
   const handleShow = () => {
-    setShowModal(true)
-    setFetchSchedules(true)
+    setShowModal(true);
+    setFetchSchedules(true);
   };
   const handleClose = () => {
     setShowModal(false);
     setFetchSchedules(false);
-  }
+  };
 
   const {
     data: schedules,
@@ -47,9 +47,10 @@ export default function SectionsTable({ sections }) {
     // Stryker disable next-line all : don't test internal caching of React Query
     ["/api/personalschedules/all"],
     // Stryker disable next-line all : don't test internal caching of React Query
-    { method: "GET", url: "/api/personalschedules/all"},
+    { method: "GET", url: "/api/personalschedules/all" },
     [],
-    {enabled: fetchSchedules}
+    // Stryker disable next-line all : testing this would be hard as it has a default value of true in utils/useBackend.js
+    { enabled: fetchSchedules }, // only calls useBackend when the modal is opened so that we dont get constant backend calls failure when not signed in
   );
 
   // Stryker disable all : not sure how to test/mock local storage
@@ -92,20 +93,21 @@ export default function SectionsTable({ sections }) {
   );
 
   const addCallback = (section) => {
-    console.log(section);
-    setSelectedEnrollCode(section.section.enrollCode);
+    if (section.section) {
+      setSelectedEnrollCode(section.section.enrollCode);
+    } else {
+      setSelectedEnrollCode(section.cells[9].value);
+    }
     handleShow();
   };
 
-
   const saveCallback = () => {
     const psId = {
-      psId: localStorage["CourseForm-psId"],
+      psId: localStorage["ModalForm-psId"],
     };
-    const dataFinal = {psId, enrollCd: selectedEnrollCode} 
+    const dataFinal = { psId, enrollCd: selectedEnrollCode };
     mutation.mutate(dataFinal);
   };
-
 
   // Stryker restore all
   // Stryker disable BooleanLiteral
@@ -217,9 +219,7 @@ export default function SectionsTable({ sections }) {
 
   const testid = "SectionsTable";
 
-  const buttonColumns = [
-    ...columns,
-  ];
+  const buttonColumns = [...columns];
 
   const columnsToDisplay = buttonColumns;
 
@@ -240,20 +240,20 @@ export default function SectionsTable({ sections }) {
         <Modal.Body>
           {/* Modal content here, such as a form to select a schedule and add a section */}
           <Form>
-          <Form.Group className="mb-3">
+            <Form.Group className="mb-3" data-testid="ModalForm-enrollCd">
               <Form.Label>Enroll Code</Form.Label>
-              <Form.Control 
-                type="text" 
-                value={selectedEnrollCode || ''} // Display the selected enroll code
-                readOnly // Make the field read-only
+              <Form.Control
+                type="text"
+                value={selectedEnrollCode || ""}
+                readOnly
               />
             </Form.Group>
-            <Form.Group className="mb-3" data-testid="CourseForm-psId">
+            <Form.Group className="mb-3" data-testid="ModalForm-psId">
               <PersonalScheduleDropdown
                 schedules={schedules}
                 schedule={schedule}
                 setSchedule={setSchedule}
-                controlId={"CourseForm-psId"}
+                controlId={"ModalForm-psId"}
               />
             </Form.Group>
           </Form>
@@ -262,11 +262,14 @@ export default function SectionsTable({ sections }) {
           <Button variant="secondary" onClick={handleClose}>
             Close
           </Button>
-          <Button variant="primary" onClick={() => {
-            // Implement the logic to add the section to a schedule here
-            saveCallback();
-            handleClose();
-          }}>
+          <Button
+            variant="primary"
+            onClick={() => {
+              // Implement the logic to add the section to a schedule here
+              saveCallback();
+              handleClose();
+            }}
+          >
             Save Changes
           </Button>
         </Modal.Footer>

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -1,6 +1,12 @@
 import SectionsTableBase from "main/components/SectionsTableBase";
+import PersonalScheduleDropdown from "../PersonalSchedules/PersonalScheduleDropdown";
 
+// import { useNavigate } from "react-router-dom";
+import React, { useState, useEffect } from 'react';
+import { Modal, Button, Form } from 'react-bootstrap';
+import { toast } from "react-toastify";
 import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import {
   convertToFraction,
   formatDays,
@@ -18,6 +24,89 @@ function getFirstVal(values) {
 }
 
 export default function SectionsTable({ sections }) {
+
+  const [showModal, setShowModal] = useState(false);
+  const [fetchSchedules, setFetchSchedules] = useState(false);
+  const [selectedEnrollCode, setSelectedEnrollCode] = useState("");
+  // const navigate = useNavigate();
+
+  const handleShow = () => {
+    setShowModal(true)
+    setFetchSchedules(true)
+  };
+  const handleClose = () => {
+    setShowModal(false);
+    setFetchSchedules(false);
+  }
+
+  const {
+    data: schedules,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/personalschedules/all"],
+    // Stryker disable next-line all : don't test internal caching of React Query
+    { method: "GET", url: "/api/personalschedules/all"},
+    [],
+    {enabled: fetchSchedules}
+  );
+
+  // Stryker disable all : not sure how to test/mock local storage
+  const localSchedule = localStorage.getItem("ModalForm-psId");
+  const [schedule, setSchedule] = useState(localSchedule || "");
+  if (schedule) {
+    localStorage.setItem("ModalForm-psId", schedule);
+  }
+  // Stryker restore all
+
+  useEffect(() => {
+    if (schedules && schedules.length > 0 && !localSchedule) {
+      setSchedule(schedules[0].id);
+      // Stryker disable all : not sure how to test/mock local storage
+      localStorage.setItem("ModalForm-psId", schedules[0].id);
+      // Stryker restore all
+    }
+  }, [schedules, localSchedule]);
+
+  const objectToAxiosParams = (course) => ({
+    url: "/api/courses/post",
+    method: "POST",
+    params: {
+      enrollCd: course.enrollCd,
+      psId: course.psId.psId,
+    },
+  });
+
+  const onSuccess = (course) => {
+    toast(
+      `New course Created - id: ${course[0].id} enrollCd: ${course[0].enrollCd}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    // ["/api/courses/user/all"],
+  );
+
+  const addCallback = (section) => {
+    console.log(section);
+    setSelectedEnrollCode(section.section.enrollCode);
+    handleShow();
+  };
+
+
+  const saveCallback = () => {
+    const psId = {
+      psId: localStorage["CourseForm-psId"],
+    };
+    const dataFinal = {psId, enrollCd: selectedEnrollCode} 
+    mutation.mutate(dataFinal);
+  };
+
+
   // Stryker restore all
   // Stryker disable BooleanLiteral
   const columns = [
@@ -128,13 +217,60 @@ export default function SectionsTable({ sections }) {
 
   const testid = "SectionsTable";
 
-  const columnsToDisplay = columns;
+  const buttonColumns = [
+    ...columns,
+  ];
+
+  const columnsToDisplay = buttonColumns;
 
   return (
-    <SectionsTableBase
-      data={sections}
-      columns={columnsToDisplay}
-      testid={testid}
-    />
+    <>
+      <SectionsTableBase
+        data={sections}
+        columns={columnsToDisplay}
+        testid={testid}
+        addCallback={addCallback}
+      />
+
+      {/* Modal JSX */}
+      <Modal show={showModal} onHide={handleClose}>
+        <Modal.Header closeButton>
+          <Modal.Title>Add Section to Schedule</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          {/* Modal content here, such as a form to select a schedule and add a section */}
+          <Form>
+          <Form.Group className="mb-3">
+              <Form.Label>Enroll Code</Form.Label>
+              <Form.Control 
+                type="text" 
+                value={selectedEnrollCode || ''} // Display the selected enroll code
+                readOnly // Make the field read-only
+              />
+            </Form.Group>
+            <Form.Group className="mb-3" data-testid="CourseForm-psId">
+              <PersonalScheduleDropdown
+                schedules={schedules}
+                schedule={schedule}
+                setSchedule={setSchedule}
+                controlId={"CourseForm-psId"}
+              />
+            </Form.Group>
+          </Form>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={handleClose}>
+            Close
+          </Button>
+          <Button variant="primary" onClick={() => {
+            // Implement the logic to add the section to a schedule here
+            saveCallback();
+            handleClose();
+          }}>
+            Save Changes
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </>
   );
 }

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -80,18 +80,18 @@ export default function SectionsTableBase({
                           background: cell.isGrouped
                             ? "#34859b"
                             : cell.isAggregated
-                              ? "#34859b"
-                              : "#9dbfbe",
+                            ? "#34859b"
+                            : "#9dbfbe",
                           color: cell.isGrouped
                             ? "#effcf4"
                             : cell.isAggregated
-                              ? "#effcf4"
-                              : "#000000",
+                            ? "#effcf4"
+                            : "#000000",
                           fontWeight: cell.isGrouped
                             ? "bold"
                             : cell.isAggregated
-                              ? "bold"
-                              : "normal",
+                            ? "bold"
+                            : "normal",
                         }}
                       >
                         {cell.isGrouped ? (

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -18,7 +18,7 @@ export default function SectionsTableBase({
         Cell: ({ row }) => {
           if (row.original || (!row.original && row.subRows.length === 1)) {
             return (
-              <Button
+              <Button style={{backgroundColor: "#003660", borderColor: "#003660"}}
                 onClick={() => addCallback(row.original ? row.original : row)}
               >
                 Add
@@ -78,10 +78,10 @@ export default function SectionsTableBase({
                         // Stryker disable next-line ObjectLiteral
                         style={{
                           background: cell.isGrouped
-                            ? "#7baacb"
+                            ? "#34859b"
                             : cell.isAggregated
-                            ? "#7baacb"
-                            : "#a3cdd9",
+                            ? "#34859b"
+                            : "#9dbfbe",
                           color: cell.isGrouped
                             ? "#effcf4"
                             : cell.isAggregated

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -1,27 +1,45 @@
-import React, { Fragment } from "react";
-import { useTable, useGroupBy, useExpanded } from "react-table";
-import { Table } from "react-bootstrap";
+import React, { Fragment } from 'react';
+import { useTable, useGroupBy, useExpanded } from 'react-table';
+import { Table, Button } from 'react-bootstrap';
 
-// Stryker disable StringLiteral, ArrayDeclaration
 export default function SectionsTableBase({
   columns,
   data,
-  testid = "testid",
+  testid = 'testid',
+  addCallback, // Make sure to pass this function as a prop from the parent component
 }) {
-  // Stryker disable next-line ObjectLiteral
-  const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
-    useTable(
-      {
-        initialState: {
-          groupBy: ["courseInfo.courseId"],
-          hiddenColumns: ["isSection"],
-        },
-        columns,
-        data,
+  const extendedColumns = React.useMemo(() => [
+    ...columns,
+    {
+      id: 'addAction',
+      Header: 'Add',
+      Cell: ({ row }) => {
+        // Render the Add button only for section rows, identified by not being grouped
+        if (row.original || (!row.original && row.subRows.length == 1)) {
+          return <Button onClick={() => addCallback(row.original)}>Add</Button>;
+        }
+        return null; // Return null for rows that should not have an Add button (like grouped rows)
+      }
+    }
+  ], [columns, addCallback]);
+  const {
+    getTableProps,
+    getTableBodyProps,
+    headerGroups,
+    rows,
+    prepareRow,
+  } = useTable(
+    {
+      initialState: {
+        groupBy: ['courseInfo.courseId'],
+        hiddenColumns: ['isSection'],
       },
-      useGroupBy,
-      useExpanded,
-    );
+      columns: extendedColumns,
+      data,
+    },
+    useGroupBy,
+    useExpanded
+  );
 
   return (
     <Table {...getTableProps()} striped bordered hover>
@@ -44,58 +62,36 @@ export default function SectionsTableBase({
           prepareRow(row);
           return (
             <Fragment key={`row-${i}`}>
-              {row.cells[0].isGrouped ||
-              (!row.cells[0].isGrouped && row.allCells[3].value) ? (
-                <tr {...row.getRowProps()}>
-                  {row.cells.map((cell, _index) => {
-                    return (
-                      <td
-                        {...cell.getCellProps()}
-                        data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
-                        // Stryker disable next-line ObjectLiteral
-                        style={{
-                          background: cell.isGrouped
-                            ? "#34859b"
-                            : cell.isAggregated
-                            ? "#34859b"
-                            : "#9dbfbe",
-                          color: cell.isGrouped
-                            ? "#effcf4"
-                            : cell.isAggregated
-                            ? "#effcf4"
-                            : "#000000",
-                          fontWeight: cell.isGrouped
-                            ? "bold"
-                            : cell.isAggregated
-                            ? "bold"
-                            : "normal",
-                        }}
-                      >
-                        {cell.isGrouped ? (
-                          <>
-                            <span
-                              {...row.getToggleRowExpandedProps()}
-                              data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-expand-symbols`}
-                            >
-                              {row.subRows.length > 1
-                                ? row.isExpanded
-                                  ? "➖ "
-                                  : "➕ "
-                                : null}
-                            </span>{" "}
-                            {cell.render("Cell")}
-                          </>
-                        ) : cell.isAggregated ? (
-                          cell.render("Aggregated")
-                        ) : (
-                          cell.render("Cell")
-                        )}
-                        <></>
-                      </td>
-                    );
-                  })}
-                </tr>
-              ) : null}
+              <tr {...row.getRowProps()}>
+                {row.cells.map((cell, _index) => {
+                  return (
+                    <td
+                      {...cell.getCellProps()}
+                      data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
+                      style={{
+                        background: cell.isGrouped ? '#34859b' : cell.isAggregated ? '#34859b' : '#9dbfbe',
+                        color: cell.isGrouped ? '#effcf4' : cell.isAggregated ? '#effcf4' : '#000000',
+                        fontWeight: cell.isGrouped ? 'bold' : cell.isAggregated ? 'bold' : 'normal',
+                      }}
+                    >
+                      {cell.isGrouped ? (
+                        <>
+                          <span {...row.getToggleRowExpandedProps()} data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-expand-symbols`}>
+                            {row.subRows.length > 1 ? (row.isExpanded ? '➖ ' : '➕ ') : null}
+                          </span>
+                          {cell.render('Cell')}
+                        </>
+                      ) : cell.isAggregated ? (
+                        cell.render('Aggregated')
+                      ) : (
+                        <>
+                        {cell.render('Cell')}
+                        </>
+                      )}
+                    </td>
+                  );
+                })}
+              </tr>
             </Fragment>
           );
         })}

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -81,18 +81,18 @@ export default function SectionsTableBase({
                           background: cell.isGrouped
                             ? "#34859b"
                             : cell.isAggregated
-                              ? "#34859b"
-                              : "#9dbfbe",
+                            ? "#34859b"
+                            : "#9dbfbe",
                           color: cell.isGrouped
                             ? "#effcf4"
                             : cell.isAggregated
-                              ? "#effcf4"
-                              : "#000000",
+                            ? "#effcf4"
+                            : "#000000",
                           fontWeight: cell.isGrouped
                             ? "bold"
                             : cell.isAggregated
-                              ? "bold"
-                              : "normal",
+                            ? "bold"
+                            : "normal",
                         }}
                       >
                         {cell.isGrouped ? (

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -18,12 +18,14 @@ export default function SectionsTableBase({
         Cell: ({ row }) => {
           if (row.original || (!row.original && row.subRows.length === 1)) {
             return (
+              //Stryker disable all : no need to test color of a button
               <Button
                 style={{ backgroundColor: "#003660", borderColor: "#003660" }}
                 onClick={() => addCallback(row.original ? row.original : row)}
               >
                 Add
               </Button>
+              //Stryker restore all
             );
           }
           return null;

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -1,45 +1,50 @@
-import React, { Fragment } from 'react';
-import { useTable, useGroupBy, useExpanded } from 'react-table';
-import { Table, Button } from 'react-bootstrap';
+import React, { Fragment } from "react";
+import { useTable, useGroupBy, useExpanded } from "react-table";
+import { Table, Button } from "react-bootstrap";
 
+// Stryker disable StringLiteral, ArrayDeclaration
 export default function SectionsTableBase({
   columns,
   data,
-  testid = 'testid',
-  addCallback, // Make sure to pass this function as a prop from the parent component
+  testid = "testid",
+  addCallback,
 }) {
-  const extendedColumns = React.useMemo(() => [
-    ...columns,
-    {
-      id: 'addAction',
-      Header: 'Add',
-      Cell: ({ row }) => {
-        // Render the Add button only for section rows, identified by not being grouped
-        if (row.original || (!row.original && row.subRows.length == 1)) {
-          return <Button onClick={() => addCallback(row.original)}>Add</Button>;
-        }
-        return null; // Return null for rows that should not have an Add button (like grouped rows)
-      }
-    }
-  ], [columns, addCallback]);
-  const {
-    getTableProps,
-    getTableBodyProps,
-    headerGroups,
-    rows,
-    prepareRow,
-  } = useTable(
-    {
-      initialState: {
-        groupBy: ['courseInfo.courseId'],
-        hiddenColumns: ['isSection'],
+  const extendedColumns = React.useMemo(
+    () => [
+      ...columns,
+      {
+        id: "addAction",
+        Header: "Add Section",
+        Cell: ({ row }) => {
+          if (row.original || (!row.original && row.subRows.length === 1)) {
+            return (
+              <Button
+                onClick={() => addCallback(row.original ? row.original : row)}
+              >
+                Add
+              </Button>
+            );
+          }
+          return null;
+        },
       },
-      columns: extendedColumns,
-      data,
-    },
-    useGroupBy,
-    useExpanded
+    ],
+    [columns, addCallback],
   );
+  // Stryker disable next-line ObjectLiteral
+  const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
+    useTable(
+      {
+        initialState: {
+          groupBy: ["courseInfo.courseId"],
+          hiddenColumns: ["isSection"],
+        },
+        columns: extendedColumns,
+        data,
+      },
+      useGroupBy,
+      useExpanded,
+    );
 
   return (
     <Table {...getTableProps()} striped bordered hover>
@@ -62,36 +67,57 @@ export default function SectionsTableBase({
           prepareRow(row);
           return (
             <Fragment key={`row-${i}`}>
-              <tr {...row.getRowProps()}>
-                {row.cells.map((cell, _index) => {
-                  return (
-                    <td
-                      {...cell.getCellProps()}
-                      data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
-                      style={{
-                        background: cell.isGrouped ? '#34859b' : cell.isAggregated ? '#34859b' : '#9dbfbe',
-                        color: cell.isGrouped ? '#effcf4' : cell.isAggregated ? '#effcf4' : '#000000',
-                        fontWeight: cell.isGrouped ? 'bold' : cell.isAggregated ? 'bold' : 'normal',
-                      }}
-                    >
-                      {cell.isGrouped ? (
-                        <>
-                          <span {...row.getToggleRowExpandedProps()} data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-expand-symbols`}>
-                            {row.subRows.length > 1 ? (row.isExpanded ? '➖ ' : '➕ ') : null}
-                          </span>
-                          {cell.render('Cell')}
-                        </>
-                      ) : cell.isAggregated ? (
-                        cell.render('Aggregated')
-                      ) : (
-                        <>
-                        {cell.render('Cell')}
-                        </>
-                      )}
-                    </td>
-                  );
-                })}
-              </tr>
+              {row.cells[0].isGrouped ||
+              (!row.cells[0].isGrouped && row.allCells[3].value) ? (
+                <tr {...row.getRowProps()}>
+                  {row.cells.map((cell, _index) => {
+                    return (
+                      <td
+                        {...cell.getCellProps()}
+                        data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
+                        // Stryker disable next-line ObjectLiteral
+                        style={{
+                          background: cell.isGrouped
+                            ? "#34859b"
+                            : cell.isAggregated
+                              ? "#34859b"
+                              : "#9dbfbe",
+                          color: cell.isGrouped
+                            ? "#effcf4"
+                            : cell.isAggregated
+                              ? "#effcf4"
+                              : "#000000",
+                          fontWeight: cell.isGrouped
+                            ? "bold"
+                            : cell.isAggregated
+                              ? "bold"
+                              : "normal",
+                        }}
+                      >
+                        {cell.isGrouped ? (
+                          <>
+                            <span
+                              {...row.getToggleRowExpandedProps()}
+                              data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-expand-symbols`}
+                            >
+                              {row.subRows.length > 1
+                                ? row.isExpanded
+                                  ? "➖ "
+                                  : "➕ "
+                                : null}
+                            </span>
+                            {cell.render("Cell")}
+                          </>
+                        ) : cell.isAggregated ? (
+                          cell.render("Aggregated")
+                        ) : (
+                          <>{cell.render("Cell")}</>
+                        )}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ) : null}
             </Fragment>
           );
         })}

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -18,7 +18,8 @@ export default function SectionsTableBase({
         Cell: ({ row }) => {
           if (row.original || (!row.original && row.subRows.length === 1)) {
             return (
-              <Button style={{backgroundColor: "#003660", borderColor: "#003660"}}
+              <Button
+                style={{ backgroundColor: "#003660", borderColor: "#003660" }}
                 onClick={() => addCallback(row.original ? row.original : row)}
               >
                 Add
@@ -80,18 +81,18 @@ export default function SectionsTableBase({
                           background: cell.isGrouped
                             ? "#34859b"
                             : cell.isAggregated
-                            ? "#34859b"
-                            : "#9dbfbe",
+                              ? "#34859b"
+                              : "#9dbfbe",
                           color: cell.isGrouped
                             ? "#effcf4"
                             : cell.isAggregated
-                            ? "#effcf4"
-                            : "#000000",
+                              ? "#effcf4"
+                              : "#000000",
                           fontWeight: cell.isGrouped
                             ? "bold"
                             : cell.isAggregated
-                            ? "bold"
-                            : "normal",
+                              ? "bold"
+                              : "normal",
                         }}
                       >
                         {cell.isGrouped ? (

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -78,10 +78,10 @@ export default function SectionsTableBase({
                         // Stryker disable next-line ObjectLiteral
                         style={{
                           background: cell.isGrouped
-                            ? "#34859b"
+                            ? "#7baacb"
                             : cell.isAggregated
-                            ? "#34859b"
-                            : "#9dbfbe",
+                            ? "#7baacb"
+                            : "#a3cdd9",
                           color: cell.isGrouped
                             ? "#effcf4"
                             : cell.isAggregated

--- a/frontend/src/main/utils/useBackend.js
+++ b/frontend/src/main/utils/useBackend.js
@@ -25,7 +25,7 @@ import { toast } from "react-toastify";
 //     []
 // );
 
-export function useBackend(queryKey, axiosParameters, initialData, rest) {
+export function useBackend(queryKey, axiosParameters, initialData, { enabled = true, ...rest } = {}) {
   return useQuery({
     queryKey: queryKey,
     queryFn: async () => {
@@ -45,6 +45,7 @@ export function useBackend(queryKey, axiosParameters, initialData, rest) {
       console.error(errorMessage);
     },
     initialData: initialData,
+    enabled,
     ...rest,
   });
 }

--- a/frontend/src/main/utils/useBackend.js
+++ b/frontend/src/main/utils/useBackend.js
@@ -25,7 +25,12 @@ import { toast } from "react-toastify";
 //     []
 // );
 
-export function useBackend(queryKey, axiosParameters, initialData, { enabled = true, ...rest } = {}) {
+export function useBackend(
+  queryKey,
+  axiosParameters,
+  initialData,
+  { enabled = true, ...rest } = {},
+) {
   return useQuery({
     queryKey: queryKey,
     queryFn: async () => {

--- a/frontend/src/tests/components/Sections/SectionsTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsTable.test.js
@@ -498,8 +498,11 @@ describe("Section tests", () => {
     expect(await screen.findByTestId("ModalForm-enrollCd")).toBeInTheDocument();
     const saveChangesButton = screen.getByText("Save Changes");
     fireEvent.click(saveChangesButton);
-    await waitFor(() => {
-      expect(localStorage.getItem("ModalForm-psId")).toBe("17");
-    }, {timeout: 5000});
+    await waitFor(
+      () => {
+        expect(localStorage.getItem("ModalForm-psId")).toBe("17");
+      },
+      { timeout: 5000 },
+    );
   });
 });

--- a/frontend/src/tests/components/Sections/SectionsTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsTable.test.js
@@ -496,8 +496,10 @@ describe("Section tests", () => {
     fireEvent.click(addButton);
 
     expect(await screen.findByTestId("ModalForm-enrollCd")).toBeInTheDocument();
+    const saveChangesButton = screen.getByText("Save Changes");
+    fireEvent.click(saveChangesButton);
     await waitFor(() => {
       expect(localStorage.getItem("ModalForm-psId")).toBe("17");
-    });
+    }, {timeout: 5000});
   });
 });

--- a/frontend/src/tests/components/SectionsTableBase.test.js
+++ b/frontend/src/tests/components/SectionsTableBase.test.js
@@ -146,7 +146,7 @@ describe("SectionsTableBase tests", () => {
       screen.getByTestId("testid-cell-row-0-col-courseInfo.courseId"),
     ).toHaveAttribute(
       "style",
-      "background: rgb(123, 170, 203); color: rgb(239, 252, 244); font-weight: bold;",
+      "background: rgb(52, 133, 155); color: rgb(239, 252, 244); font-weight: bold;",
     );
   });
 });

--- a/frontend/src/tests/components/SectionsTableBase.test.js
+++ b/frontend/src/tests/components/SectionsTableBase.test.js
@@ -146,7 +146,7 @@ describe("SectionsTableBase tests", () => {
       screen.getByTestId("testid-cell-row-0-col-courseInfo.courseId"),
     ).toHaveAttribute(
       "style",
-      "background: rgb(52, 133, 155); color: rgb(239, 252, 244); font-weight: bold;",
+      "background: rgb(123, 170, 203); color: rgb(239, 252, 244); font-weight: bold;",
     );
   });
 });


### PR DESCRIPTION
Closes #7 

Dev deployment: https://proj-courses-theanimated01-dev.dokku-07.cs.ucsb.edu/

This PR adds a feature where you can directly add courses to a schedule from the courses search page.

Changes made:

1. Edited SectionTable.js to include a new modal when you press the Add Button
2. Edited SectionTableBase.js to include a column with the Add button. Add button only appears beside sections when a course is expanded. If a course does not have sections (i.e. not expandable) the Add button will appear beside the course
3. Modified the useBackend.js under utils so I could call that hook based on a boolean value. It was required otherwise the homepage would throw a error 403 (communicating with backend) as we are not signed in when we first open the home page and I used the backend call to populate the schedule dropdown in the modal. The boolean allowed me to call the useBackend function only when the modal was opened.
4. Edited test file for SectionTable

Screenshots for before and after:
<img width="1440" alt="Screenshot 2024-03-07 at 12 22 05 AM" src="https://github.com/ucsb-cs156-w24/proj-courses-w24-5pm-3/assets/79371675/962da11a-d90c-4c2b-ae6c-6b4df161a6e1">
<img width="1440" alt="Screenshot 2024-03-07 at 5 28 42 PM" src="https://github.com/ucsb-cs156-w24/proj-courses-w24-5pm-3/assets/79371675/cc24111b-87dc-40db-a218-33458390b57d">
<img width="1440" alt="Screenshot 2024-03-07 at 5 30 29 PM" src="https://github.com/ucsb-cs156-w24/proj-courses-w24-5pm-3/assets/79371675/6336f93a-d307-4ac6-bd26-c0e2ef06844c">

